### PR TITLE
Fix References to matchForm.json & Fix Missing scouts.json in searchDB.js

### DIFF
--- a/lib/searchDB.js
+++ b/lib/searchDB.js
@@ -1,7 +1,14 @@
 const fs = require("fs-extra");
-var inputsFile = JSON.parse(fs.readFileSync('./json/matchForm.json', 'utf8'));
-var scoutIDs = JSON.parse(fs.readFileSync('./json/scouts.json', 'utf8'));
+var inputsFile = JSON.parse(fs.readFileSync('./json/inputs.json', 'utf8')); // Form Data
+var scoutIDs = []; // Local Scout Information
 
+// Check for ScoutIDs, Generate File if DNE
+if (fs.existsSync("./json/scouts.json")) { // If Scout Identification Exists, Load to Local
+	scoutIDs = JSON.parse(fs.readFileSync('./json/scouts.json', 'utf8'));
+} else {
+	scoutIDs = [{"id": "000000", "name": "Administrator"}];
+	fs.outputFileSync("./json/scouts.json", "[{\n    \"id\": \"000000\",\n    \"name\": \"Administrator\",\n    \"separate\": false\n  }\n]");
+}
 
 function parseFilters(field) {
 	console.log(field);
@@ -96,7 +103,6 @@ function isValidScoutID(id) { // Check a given ScoutID against valid IDs
 	for(var i = 0; i < scoutIDs.length; i++) {
 		if(scoutIDs[i].id == id) {
 			return true;
-			break;
 		}
 	}
 }
@@ -105,20 +111,14 @@ function getScoutName(id) { // Get Scout Name from a ScoutID
 	for(var i = 0; i < scoutIDs.length; i++) {
 		if(scoutIDs[i].id == id) {
 			return scoutIDs[i].name;
-			break;
 		}
 	}
 	return null;
 }
 
 module.exports = {
-	searchDB: function(obj, searchObj) {
-		return searchDB(obj, searchObj);
-	},
-	isValidScoutID: function(id) {
-		return isValidScoutID(id)
-	},
-	getScoutName: function(id) {
-		return getScoutName(id)
-	}
+	searchDB: searchDB,
+	isValidScoutID: isValidScoutID,
+	getScoutName: getScoutName,
+	scoutIDs: scoutIDs
 }

--- a/main.js
+++ b/main.js
@@ -68,7 +68,7 @@ function checkDuplicateItems(formConfig) { // Check a given Form Configuration f
 
 
 // Debug Logging
-console.log('Loading Resources...' + (debug ? '\n[DEBUG MODE ENABLED\n\n' : '\n\n'));
+console.log('Loading Resources...' + (debug ? '\n[DEBUG MODE ENABLED]\n\n' : '\n\n'));
 
 
 // Import Static Data

--- a/main.js
+++ b/main.js
@@ -18,7 +18,6 @@ const debug = true;
 
 // Container Variables
 var dbArray = []; // Local Scouting Database
-var scoutIDs = []; // Local Scout Information
 
 
 // Helper Functions
@@ -73,19 +72,13 @@ console.log('Loading Resources...' + (debug ? '\n[DEBUG MODE ENABLED\n\n' : '\n\
 
 
 // Import Static Data
-var formConfig = JSON.parse(fs.readFileSync('./json/matchForm.json', 'utf8')); // Scouting Form Configuration Data
+var formConfig = JSON.parse(fs.readFileSync('./json/inputs.json', 'utf8')); // Scouting Form Configuration Data
 var templateMetadata = fs.readFileSync('./html/templates/meta.html', 'utf8');; // Template Metadata
+var scoutIDs = JSON.parse(fs.readFileSync('./json/scouts.json', 'utf8')); // IDs of Registered Scouts
 
 
-// Generate ScoutIDs
-if (fs.existsSync("./json/scouts.json")) { // If Scout Identification Exists, Load to Local
-	scoutIDs = JSON.parse(fs.readFileSync('./json/scouts.json', 'utf8'));
-} else {
-	scoutIDs = [{"id": "000000", "name": "Administrator"}];
-	fs.outputFileSync("./json/scouts.json", "[{\n    \"id\": \"000000\",\n    \"name\": \"Administrator\",\n    \"separate\": false,\n  }\n]");
-}
-
-if (debug) { // Log Scout Information
+// Log Scout Information
+if (debug) {
 	console.log('Registered Scouts:')
 	for (scout of scoutIDs) {
 		console.log(`[${scout.id}] ${scout.name}` + (scout.seperate ? ' - Data Seperated' : '')); // Show Seperation if Enabled


### PR DESCRIPTION
`matchForm.json` had been renamed to `inputs.json` in previous commit, but references to the file had not cycled down.  Also, while the script did have functionality to generate the missing `scouts.json` file, that code had not made its way over to `searchDB.js` when other scoutID functionality was transitioned there.